### PR TITLE
Switch to table markup in chapter 6

### DIFF
--- a/src/epub/text/chapter-6.xhtml
+++ b/src/epub/text/chapter-6.xhtml
@@ -18,13 +18,36 @@
 			<p>“There are obligations as well as interests,” said Mother seriously. “Try to make <b><span epub:type="z3998:roman">V</span>a</b> a useful factor in the school. That would be something worth doing, wouldn’t it?”</p>
 			<p>In arranging for the School Parliament, Miss Burd had allowed wardens to be chosen by each form, from <b><span epub:type="z3998:roman">III</span>b</b> upwards, but had decided that the smaller girls were too young to take part in public affairs. Every form that sent a representative constituted itself into a kind of club, and chose a special name. These were placed on the Council Register as follows:</p>
 			<blockquote>
-				<p><b epub:type="z3998:roman">VI</b> The True Blues.<br/>
-				<b><span epub:type="z3998:roman">V</span>a</b> The Pioneers.<br/>
-				<b><span epub:type="z3998:roman">V</span>b</b> The Amazons.<br/>
-				<b><span epub:type="z3998:roman">IV</span>a</b> The Old Brigade.<br/>
-				<b><span epub:type="z3998:roman">IV</span>b</b> The Mermaids.<br/>
-				<b><span epub:type="z3998:roman">III</span>a</b> The Dragonflies.<br/>
-				<b><span epub:type="z3998:roman">III</span>b</b> The Cuckoos.</p>
+				<table>
+					<tr>
+						<td><b epub:type="z3998:roman">VI</b></td>
+						<td>The True Blues.</td>
+					</tr>
+					<tr>
+						<td><b><span epub:type="z3998:roman">V</span>a</b></td>
+						<td>The Pioneers.</td>
+					</tr>
+					<tr>
+						<td><b><span epub:type="z3998:roman">V</span>b</b></td>
+						<td>The Amazons.</td>
+					</tr>
+					<tr>
+						<td><b><span epub:type="z3998:roman">IV</span>a</b></td>
+						<td>The Old Brigade.</td>
+					</tr>
+					<tr>
+						<td><b><span epub:type="z3998:roman">IV</span>b</b></td>
+						<td>The Mermaids.</td>
+					</tr>
+					<tr>
+						<td><b><span epub:type="z3998:roman">III</span>a</b></td>
+						<td>The Dragonflies.</td>
+					</tr>
+					<tr>
+						<td><b><span epub:type="z3998:roman">III</span>b</b></td>
+						<td>The Cuckoos.</td>
+					</tr>
+				</table>
 			</blockquote>
 			<p>“You can compare marks every fortnight,” said Miss Burd, “and whichever gets the best average shall hold a cup that I intend to present. The marks of the whole form will count, so that slackers will be a distinct drawback to their own companies. Any girl who loses a mark hinders her form from gaining the cup, and of course vice versa, those who work will help.”</p>
 			<p>The question of marks had been a much debated subject with Miss Burd. She had discussed it in detail at several educational conferences, and had come to the conclusion that, on the whole, the system was highly desirable.</p>


### PR DESCRIPTION
![scan](https://github.com/user-attachments/assets/1f6e6b45-0329-45c1-807a-a250907229dc)

```css
#chapter-6 blockquote p > b{
        display: block;
        margin: 1em 0;
        text-align: center;
}
```

```html
			<blockquote>
				<p><b epub:type="z3998:roman">VI</b> The True Blues.<br/>
				<b><span epub:type="z3998:roman">V</span>a</b> The Pioneers.<br/>
				<b><span epub:type="z3998:roman">V</span>b</b> The Amazons.<br/>
				<b><span epub:type="z3998:roman">IV</span>a</b> The Old Brigade.<br/>
				<b><span epub:type="z3998:roman">IV</span>b</b> The Mermaids.<br/>
				<b><span epub:type="z3998:roman">III</span>a</b> The Dragonflies.<br/>
				<b><span epub:type="z3998:roman">III</span>b</b> The Cuckoos.</p>
			</blockquote>
```

![ebook](https://github.com/user-attachments/assets/8de8777c-d7e5-40d8-8f5a-c46d472b929f)

Giving the numbers their own centered block like this makes no sense. I think this CSS is catching this blockquote by accident, and was only intended to affect a different blockquote later in the chapter.

Table markup seems appropriate here and coincidentally means the CSS only affects what it was meant to affect. I didn’t center the table like the scan, it seems unnecessary.